### PR TITLE
Add an option "allow_empty_commits"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ GitHub Actions to publish AUR package.
 
 **Optional** Commit message to use when creating the new commit.
 
+### `allow_empty_commits`
+
+**Optional** Allow empty commits, i.e. commits with no change. The default value is `true`.
+
 ### `ssh_keyscan_types`
 
 **Optional** Comma-separated list of types to use when adding aur.archlinux.org to known hosts.

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Commit message to use when creating the new commit'
     required: false
     default: 'Update PKGBUILD and .SRCINFO with GitHub Actions'
+  allow_empty_commits:
+    description: 'Allow empty commits, i.e. commits with no change.'
+    required: false
+    default: 'true'
   ssh_keyscan_types:
     description: 'Comma-separated list of types to use when adding aur.archlinux.org to known hosts'
     required: false

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ commit_username=$INPUT_COMMIT_USERNAME
 commit_email=$INPUT_COMMIT_EMAIL
 ssh_private_key=$INPUT_SSH_PRIVATE_KEY
 commit_message=$INPUT_COMMIT_MESSAGE
+allow_empty_commits=$INPUT_ALLOW_EMPTY_COMMITS
 ssh_keyscan_types=$INPUT_SSH_KEYSCAN_TYPES
 
 export HOME=/home/builder
@@ -49,6 +50,10 @@ echo '::endgroup::'
 echo '::group::Publishing'
 git remote add aur "ssh://aur@aur.archlinux.org/${pkgname}.git"
 git add -fv PKGBUILD .SRCINFO
-git commit --allow-empty -m "$commit_message"
+if [[ $allow_empty_commits == 'true' ]]; then
+    git commit --allow-empty -m "$commit_message"
+else
+    git diff-index --quiet HEAD || git commit -m "$commit_message" # use `git diff-index --quiet HEAD ||` to avoid error
+fi
 git push -fv aur master
 echo '::endgroup::'

--- a/build.sh
+++ b/build.sh
@@ -55,5 +55,5 @@ if [[ $allow_empty_commits == 'true' ]]; then
 else
     git diff-index --quiet HEAD || git commit -m "$commit_message" # use `git diff-index --quiet HEAD ||` to avoid error
 fi
-git push -fv aur master
+git push --force-with-lease -v aur master
 echo '::endgroup::'


### PR DESCRIPTION
I have no idea why anyone wants `--allow-empty`. However, I don't want to make a breaking change, so we can add an option.