### PR TITLE
Add `updpkgsums` option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN pacman -S --noconfirm --needed --overwrite '*' \
       openssh sudo \
       git fakeroot binutils gcc awk binutils xz \
       libarchive bzip2 coreutils file findutils \
-      gettext grep gzip sed ncurses util-linux
+      gettext grep gzip sed ncurses util-linux \
+      pacman-contrib
 
 COPY entrypoint.sh /entrypoint.sh
 COPY build.sh /build.sh

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Newline-separated glob patterns for additional files to be added to the AUR repository'
     required: false
     default: ''
+  updpkgsums:
+    description: 'Update checksums using `updpkgsums`'
+    required: false
+    default: 'false'
   commit_username:
     description: 'The username to use when creating the new commit'
     required: true

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@ set -o errexit -o pipefail -o nounset
 pkgname=$INPUT_PKGNAME
 pkgbuild=$INPUT_PKGBUILD
 assets=$INPUT_ASSETS
+updpkgsums=$INPUT_UPDPKGSUMS
 commit_username=$INPUT_COMMIT_USERNAME
 commit_email=$INPUT_COMMIT_EMAIL
 ssh_private_key=$INPUT_SSH_PRIVATE_KEY
@@ -69,6 +70,13 @@ if [[ -n "$assets" ]]; then
   cp -rt /tmp/local-repo/ $assets
 fi
 echo '::endgroup::'
+
+if [ "$updpkgsums" == "true" ]; then
+	echo '::group::Updating checksums'
+	cd /tmp/local-repo/
+	updpkgsums
+	echo '::endgroup::'
+fi
 
 echo '::group::Generating .SRCINFO'
 cd /tmp/local-repo


### PR DESCRIPTION
Most of the content of my `PKGBUILD`s can easily be updated without requiring any arch linux specific commands. The one command I do require is `updpkgsums` so it would be easier if that command is tied into this workflow instead of requiring me to make a whole new step which runs arch linux for that one command.