### PR TITLE
Add makepkg option - optional basic check that PKGBUILD could be built

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Glob patterns will be expanded by bash when copying the files to the repository.
 
 **Optional** Update checksums using `updpkgsums`.
 
-### `makepkg`
+### `test`
 
-**Optional** Build package using `makepkg` before deploy.
+**Optional** Check that PKGBUILD could be built.
 
 ### `commit_username`
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Glob patterns will be expanded by bash when copying the files to the repository.
 
 **Optional** Update checksums using `updpkgsums`.
 
+### `makepkg`
+
+**Optional** Build package using `makepkg` before deploy.
+
 ### `commit_username`
 
 **Required** The username to use when creating the new commit.

--- a/action.yml
+++ b/action.yml
@@ -19,8 +19,8 @@ inputs:
     description: 'Update checksums using `updpkgsums`'
     required: false
     default: 'false'
-  makepkg:
-    description: 'Build package using `makepkg` before deploy'
+  test:
+    description: 'Check that PKGBUILD could be built'
     required: false
     default: 'false'
   commit_username:

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Update checksums using `updpkgsums`'
     required: false
     default: 'false'
+  makepkg:
+    description: 'Build package using `makepkg` before deploy'
+    required: false
+    default: 'false'
   commit_username:
     description: 'The username to use when creating the new commit'
     required: true

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ pkgname=$INPUT_PKGNAME
 pkgbuild=$INPUT_PKGBUILD
 assets=$INPUT_ASSETS
 updpkgsums=$INPUT_UPDPKGSUMS
+makepkg=$INPUT_MAKEPKG
 commit_username=$INPUT_COMMIT_USERNAME
 commit_email=$INPUT_COMMIT_EMAIL
 ssh_private_key=$INPUT_SSH_PRIVATE_KEY
@@ -75,6 +76,13 @@ if [ "$updpkgsums" == "true" ]; then
 	echo '::group::Updating checksums'
 	cd /tmp/local-repo/
 	updpkgsums
+	echo '::endgroup::'
+fi
+
+if [ "$makepkg" == "true" ]; then
+	echo '::group::Building package with makepkg'
+	cd /tmp/local-repo/
+	makepkg --clean --cleanbuild --nodeps
 	echo '::endgroup::'
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ pkgname=$INPUT_PKGNAME
 pkgbuild=$INPUT_PKGBUILD
 assets=$INPUT_ASSETS
 updpkgsums=$INPUT_UPDPKGSUMS
-makepkg=$INPUT_MAKEPKG
+test=$INPUT_TEST
 commit_username=$INPUT_COMMIT_USERNAME
 commit_email=$INPUT_COMMIT_EMAIL
 ssh_private_key=$INPUT_SSH_PRIVATE_KEY
@@ -79,7 +79,7 @@ if [ "$updpkgsums" == "true" ]; then
 	echo '::endgroup::'
 fi
 
-if [ "$makepkg" == "true" ]; then
+if [ "$test" == "true" ]; then
 	echo '::group::Building package with makepkg'
 	cd /tmp/local-repo/
 	makepkg --clean --cleanbuild --nodeps


### PR DESCRIPTION
It'll be handy to be able to check that `makepkg` passed without errors before packaging and deploying new release. E.g., file names or paths in the source archive could be changed. And with such "test build" we could catch failed pkg before releasing.

This check is optional. Also, `makepkg` is launched with `--nodeps` option for simplicity.