### PR TITLE
Add `test_flags` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Glob patterns will be expanded by bash when copying the files to the repository.
 
 **Optional** Check that PKGBUILD could be built.
 
+### `test_flags`
+
+**Optional** Command line flags for makepkg to build the package (if `test` is enabled). The default flags are `--clean --cleanbuild --nodeps`.
+
 ### `commit_username`
 
 **Required** The username to use when creating the new commit.

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Check that PKGBUILD could be built'
     required: false
     default: 'false'
+  test_flags:
+    description: 'Command line flags for makepkg to build the package (if `test` is enabled)'
+    required: false
+    default: '--clean --cleanbuild --nodeps'
   commit_username:
     description: 'The username to use when creating the new commit'
     required: true

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ pkgbuild=$INPUT_PKGBUILD
 assets=$INPUT_ASSETS
 updpkgsums=$INPUT_UPDPKGSUMS
 test=$INPUT_TEST
+test_flags=$INPUT_TEST_FLAGS
 commit_username=$INPUT_COMMIT_USERNAME
 commit_email=$INPUT_COMMIT_EMAIL
 ssh_private_key=$INPUT_SSH_PRIVATE_KEY
@@ -82,7 +83,7 @@ fi
 if [ "$test" == "true" ]; then
 	echo '::group::Building package with makepkg'
 	cd /tmp/local-repo/
-	makepkg --clean --cleanbuild --nodeps
+	makepkg $test_flags
 	echo '::endgroup::'
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ pkgbuild=$INPUT_PKGBUILD
 assets=$INPUT_ASSETS
 updpkgsums=$INPUT_UPDPKGSUMS
 test=$INPUT_TEST
-test_flags=$INPUT_TEST_FLAGS
+read -r -a test_flags <<< "$INPUT_TEST_FLAGS"
 commit_username=$INPUT_COMMIT_USERNAME
 commit_email=$INPUT_COMMIT_EMAIL
 ssh_private_key=$INPUT_SSH_PRIVATE_KEY
@@ -83,7 +83,7 @@ fi
 if [ "$test" == "true" ]; then
 	echo '::group::Building package with makepkg'
 	cd /tmp/local-repo/
-	makepkg $test_flags
+	makepkg "${test_flags[@]}"
 	echo '::endgroup::'
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ set -o errexit -o pipefail -o nounset
 echo '::group::Creating builder user'
 useradd --create-home --shell /bin/bash builder
 passwd --delete builder
+echo "builder  ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/builder
 echo '::endgroup::'
 
 echo '::group::Initializing SSH directory'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ set -o errexit -o pipefail -o nounset
 echo '::group::Creating builder user'
 useradd --create-home --shell /bin/bash builder
 passwd --delete builder
+mkdir -p /etc/sudoers.d/
 echo "builder  ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/builder
 echo '::endgroup::'
 


### PR DESCRIPTION
I really enjoyed the `test` option to check that the package could be succesfully built with `makepkg`. The only flaw for me is that its command line flags are fixed:
https://github.com/KSXGitHub/github-actions-deploy-aur/blob/325b53d8bb2cacbb9194b68f6f377001c29c5584/build.sh#L82-L87

## Changes

This PR adds a new input called `test_flags` which sets the command line flags for `makepkg`.
Its default value falls back to the old behavior, so there are no regression problems.

Furthermore, it makes the `builder` user a sudoer so it is able to install the dependencies.

## Example

I use it [in this workflow](https://github.com/fuljo/rofi-vscode-mode/blob/9ceebcc954740712d16656a1c8cc4f241eacbc11/.github/workflows/cd.yml) where I need to install dependencies in order to build the package, and I also check that it installs successfully. Here is the interesting snippet:
```yaml
      - name: Publish PKGBUILD
        uses: fuljo/github-actions-deploy-aur@master
        with:
          pkgname: rofi-vscode-mode
          pkgbuild: PKGBUILD
          updpkgsums: true
          test: true
          test_flags: --clean --cleanbuild --syncdeps --install --noconfirm
          commit_username: ${{ secrets.AUR_USERNAME }}
          commit_email: ${{ secrets.AUR_EMAIL }}
          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
```

You can see a succesful run of my fork [here](https://github.com/fuljo/rofi-vscode-mode/actions/runs/3457181719).