### PR TITLE
pre-install `base-devel`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM archlinux:base
 
 RUN pacman -Syu --noconfirm
 RUN pacman -S --noconfirm --needed --overwrite '*' \
-      openssh sudo \
+      openssh sudo base-devel \
       git fakeroot binutils gcc awk binutils xz \
       libarchive bzip2 coreutils file findutils \
       gettext grep gzip sed ncurses util-linux \


### PR DESCRIPTION
According to [ArchWiki](https://wiki.archlinux.org/title/PKGBUILD#makedepends):

> The package [base-devel](https://archlinux.org/packages/?name=base-devel) is assumed to be already installed when building with *makepkg*.

Therefore, maybe we need to install base-devel when building the image?