### PR TITLE
fix: the position of `v` option

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,7 @@ echo '::group::Copying files into /tmp/local-repo'
 # Ignore quote rule because we need to expand glob patterns to copy $assets
 if [[ -n "$assets" ]]; then
   echo 'Copying' $assets
-  cp -rtv /tmp/local-repo/ $assets
+  cp -rvt /tmp/local-repo/ $assets
 fi
 echo '::endgroup::'
 


### PR DESCRIPTION
This PR fixes a bug that `cp: target directory 'v': No such file or directory` error occurs on copying assets, introduced in 184b3c40ce75c051264c5c0911cd8546011e8171.

The `t` option specifies the directory path, so `-rtv` order seems to cause `cp` to take `v` as a directory name.